### PR TITLE
Add Lat/lon grid generation, road snapping, and multiple images per lat/lon functionality.

### DIFF
--- a/get_images.py
+++ b/get_images.py
@@ -106,18 +106,17 @@ def get_images(lat: float, lon: float, num_images: int = 1, show_image: bool = F
     for heading in headings:
         output_dir = pathlib.Path(IMAGES_DIR)
         image, metadata = get_image(lat, lon, heading=heading)
-        # Save image to output dirs
-        if image:
-            # Get remove dots from lat and lon
-            lat_str = str(lat).replace(".", "dot")
-            lon_str = str(lon).replace(".", "dot")
-            output_file = output_dir / f"streetview_{metadata['date']}_{lat_str}_{lon_str}_{heading}.jpg"
-            with open(output_file, "wb") as file:
-                file.write(image)
-            print(f"Image saved to {output_file}")
-        else:
-            print("Failed to download image.")
-            exit()
+        if image is None:
+            raise ValueError("Failed to download image.")
+        
+        # Get remove dots from lat and lon
+        lat_str = str(lat).replace(".", "dot")
+        lon_str = str(lon).replace(".", "dot")
+        output_file = output_dir / f"streetview_{metadata['date']}_{lat_str}_{lon_str}_{heading}.jpg"
+        with open(output_file, "wb") as file:
+            file.write(image)
+        print(f"Image saved to {output_file}")
+
         if show_image:
             show_img.show_image(output_file)
 

--- a/get_images.py
+++ b/get_images.py
@@ -49,7 +49,6 @@ def get_street_view_details(lat: float, lon: float, heading: int = 0, fov: int =
     print(f"Retrieving Street View image metadata for location: {lat},{lon}")
     # Fetch metadata
     metadata_response = requests.get(metadata_url, params=params)
-    import pdb; pdb.set_trace()
     if metadata_response.status_code == 200:
         metadata = metadata_response.json()
         # Construct image URL
@@ -84,7 +83,6 @@ def get_image(lat: float, lon: float, heading: int = 0, fov: int = 120, size: st
     if size not in ["600x300", "400x400", "800x400"]:
         raise ValueError("Size must be one of '600x300', '400x400', or '800x400'.")
     image_url, metadata = get_street_view_details(lat, lon, heading, fov, size)
-    import pdb; pdb.set_trace()
     if (metadata["status"] == "ZERO_RESULTS" or metadata["status"] == "NOT_FOUND"):
         print(f"No Street View image found for the given location: {lat}, {lon}")
     elif image_url is not None:

--- a/get_images.py
+++ b/get_images.py
@@ -109,7 +109,7 @@ def get_images(lat: float, lon: float, num_images: int = 1, show_image: bool = F
         if image is None:
             raise ValueError("Failed to download image.")
         
-        # Get remove dots from lat and lon
+        # Remove dots from lat and lon
         lat_str = str(lat).replace(".", "dot")
         lon_str = str(lon).replace(".", "dot")
         output_file = output_dir / f"streetview_{metadata['date']}_{lat_str}_{lon_str}_{heading}.jpg"

--- a/get_images.py
+++ b/get_images.py
@@ -30,7 +30,7 @@ def parse_args():
         "--show-image", action="store_true", help="Display the downloaded image."
     )
     parser.add_argument(
-        '--heading', type=int, default=0, help='Heading of the Street View camera.'
+        '--num-images', type=int, default=1, help='Number of images to extract, the heading will be divided into equal parts starting at 0 and ending at 360'
     )
     args = parser.parse_args()
     return args
@@ -49,6 +49,7 @@ def get_street_view_details(lat: float, lon: float, heading: int = 0, fov: int =
     print(f"Retrieving Street View image metadata for location: {lat},{lon}")
     # Fetch metadata
     metadata_response = requests.get(metadata_url, params=params)
+    import pdb; pdb.set_trace()
     if metadata_response.status_code == 200:
         metadata = metadata_response.json()
         # Construct image URL
@@ -70,7 +71,6 @@ def get_street_view_image(image_url: str):
     print(f"Response: {response.text}")
     return None
 
-
 def get_image(lat: float, lon: float, heading: int = 0, fov: int = 120, size: str = "600x300"):
     # Retrieves metadata then retrieves the image from streetview api
     if lat < -90 or lat > 90:
@@ -84,6 +84,7 @@ def get_image(lat: float, lon: float, heading: int = 0, fov: int = 120, size: st
     if size not in ["600x300", "400x400", "800x400"]:
         raise ValueError("Size must be one of '600x300', '400x400', or '800x400'.")
     image_url, metadata = get_street_view_details(lat, lon, heading, fov, size)
+    import pdb; pdb.set_trace()
     if (metadata["status"] == "ZERO_RESULTS" or metadata["status"] == "NOT_FOUND"):
         print(f"No Street View image found for the given location: {lat}, {lon}")
     elif image_url is not None:
@@ -95,27 +96,40 @@ def get_image(lat: float, lon: float, heading: int = 0, fov: int = 120, size: st
     else:
         return None, None
         
+def get_images(lat: float, lon: float, num_images: int = 1, show_image: bool = False):
+    if num_images < 1:
+        raise ValueError("Number of images must be greater than 0.")
+    if num_images > 5:
+        raise ValueError("Number of images must be less than or equal to 5.")
+    headings = [0]
+    if num_images > 1:
+        headings = [heading for heading in range(0, 360, 360 // num_images)]
+    print(f"Generating images for headings: {headings}")
+    for heading in headings:
+        output_dir = pathlib.Path(IMAGES_DIR)
+        image, metadata = get_image(lat, lon, heading=heading)
+        # Save image to output dirs
+        if image:
+            # Get remove dots from lat and lon
+            lat_str = str(lat).replace(".", "dot")
+            lon_str = str(lon).replace(".", "dot")
+            output_file = output_dir / f"streetview_{metadata['date']}_{lat_str}_{lon_str}_{heading}.jpg"
+            with open(output_file, "wb") as file:
+                file.write(image)
+            print(f"Image saved to {output_file}")
+        else:
+            print("Failed to download image.")
+            exit()
+        if show_image:
+            show_img.show_image(output_file)
+
 if __name__ == "__main__":
     args = parse_args()
     lat = args.lat
     lon = args.lon
     show_image = args.show_image
-    heading = args.heading
-    output_dir = pathlib.Path(args.output_dir)
-    image, metadata = get_image(lat, lon, heading=heading)
-    # Save image to output dirs
-    if image:
-        # Get remove dots from lat and lon
-        lat_str = str(lat).replace(".", "dot")
-        lon_str = str(lon).replace(".", "dot")
-        output_file = output_dir / f"streetview_{metadata['date']}_{lat_str}_{lon_str}_{heading}.jpg"
-        with open(output_file, "wb") as file:
-            file.write(image)
-        print(f"Image saved to {output_file}")
-    else:
-        print("Failed to download image.")
-        exit()
-    if args.show_image:
-        show_img.show_image(output_file)  
+    num_images = args.num_images
+    print(f"Fetching {num_images} image(s) for location: {lat}, {lon}")
+    get_images(lat, lon, num_images, show_image)
 
    

--- a/get_point_grid.py
+++ b/get_point_grid.py
@@ -1,0 +1,75 @@
+import argparse
+import requests
+import numpy as np
+from typing import List, Tuple, Dict, Any
+import creds
+
+MAX_POINTS = 10000
+MIN_POINTS = 2
+
+def generate_grid(lat_start: float, lat_end: float, lon_start: float, lon_end: float, step: float) -> List[Tuple[float, float]]:
+    """Generate a grid of latitude and longitude coordinates, correctly handling both positive and negative steps."""
+    # Determine the direction of the step for latitude and longitude
+    lat_step = step if lat_end > lat_start else -step
+    lon_step = step if lon_end > lon_start else -step
+    
+    # Generate points using adjusted steps
+    lat_points = np.arange(lat_start, lat_end, lat_step)
+    lon_points = np.arange(lon_start, lon_end, lon_step)
+    
+    # Create grid using list comprehension
+    return [(lat, lon) for lat in lat_points for lon in lon_points]
+
+def snap_to_roads(coordinates: List[Tuple[float, float]]) -> List[Tuple[float, float]]:
+    """Snap a list of coordinates to the nearest roads using Google Roads API and return a list of lat/lon pairs."""
+    base_url = "https://roads.googleapis.com/v1/snapToRoads"
+    # Create the path parameter string from the coordinates list
+    path_param = "|".join([f"{lat},{lon}" for lat, lon in coordinates])
+    params = {"path": path_param, "interpolate": False, "key": creds.GOOGLE_API_KEY}
+    response = requests.get(base_url, params=params)
+    
+    if response.status_code == 200:
+        snapped_points = response.json().get('snappedPoints', [])
+        # Extract the latitude and longitude from each snapped point
+        return [(point['location']['latitude'], point['location']['longitude']) for point in snapped_points]
+    else:
+        print("API Request Failed:", response.text)
+        return []
+
+def parse_args() -> argparse.ArgumentParser:
+    """Parse command line arguments for the grid coordinates and API key, including grid resolution and maximum number of points."""
+    parser = argparse.ArgumentParser(description="Generate a grid of coordinates and snap them to the nearest roads.")
+    parser.add_argument("lat_start", type=float, help="Start latitude of the grid.")
+    parser.add_argument("lon_start", type=float, help="Start longitude of the grid.")
+    parser.add_argument("lat_end", type=float, help="End latitude of the grid.")
+    parser.add_argument("lon_end", type=float, help="End longitude of the grid.")
+    parser.add_argument("--resolution", type=float, default=0.01, help="Resolution of the grid in degrees.")
+    return parser.parse_args()
+
+def get_point_grid(lat_start: float, lon_start: float, lat_end: float, lon_end: float, resolution: float) -> List[Tuple[float, float]]:
+    if not (-90 <= lat_start <= 90 and -90 <= lat_end <= 90 and
+            -180 <= lon_start <= 180 and -180 <= lon_end <= 180):
+        print(f"Invalid latitude or longitude values: {lat_start}, {lon_start}, {lat_end}, {lon_end}")
+        return
+
+    # Use the resolution from args
+    grid_coordinates = generate_grid(lat_start, lat_end, lon_start, lon_end, resolution)
+    print(f"Generated grid of size {len(grid_coordinates)}")
+    if len(grid_coordinates) > MAX_POINTS:
+        print(f"Generated grid of size {len(grid_coordinates)} exceeds the maximum number of allowed points: {MAX_POINTS}")
+        return None
+    if len(grid_coordinates) < MIN_POINTS:
+        print(f"Generated grid of size {len(grid_coordinates)} has less than the minimum number of required points: {MIN_POINTS}")
+        return None
+
+    snapped_points = snap_to_roads(grid_coordinates)
+    print(f"Received {len(snapped_points)} snapped points from the API.")
+    return snapped_points 
+
+def main():
+    args = parse_args()
+    snapped_points = get_point_grid(args.lat_start, args.lon_start, args.lat_end, args.lon_end, args.resolution)
+    print(f"Snapped points: {snapped_points}")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
The idea here is that we will query a NxN rectangular grid of lat/lon coordinates, we can use the SnapToRoad google API to snap these points to a road. This allows us to sample at some granularity all the roads in the NxN rectangle. For lower resolutions we might lose queries on smaller roads.

**Key Changes:**

1. **Latitude/Longitude Grid Generation**:
   - A new file, `get_point_grid.py`, has been added which includes the `generate_grid` function. This function creates a grid of latitude and longitude points within specified boundaries and resolution settings.
   - The grid can handle both positive and negative step values and adjusts the step direction based on the input start and end values.

2. **Road Snapping**:
   - The `snap_to_roads` function within `get_point_grid.py` takes the generated grid points and snaps them to the nearest roads.

3. **Multiple Image Fetching**:
   - Modifications in `get_images.py` allow fetching multiple images for a given latitude and longitude. The number of images and the distribution of their headings can be specified. The `--num-images` parameter replaces the previous `--heading` parameter, now calculating multiple headings to capture images from different perspectives around the specified location.

4. **Enhanced Command Line Arguments**:
   - Both scripts now support enhanced command-line argument parsing 

5. **We should test this**

